### PR TITLE
Fix bump-version script for ESM

### DIFF
--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,7 +1,5 @@
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 const semverPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 


### PR DESCRIPTION
## Summary
- replace CommonJS require calls in scripts/bump-version.js with Node.js ESM imports so the script runs under "type": "module"

## Testing
- GITHUB_OUTPUT=$(mktemp) node scripts/bump-version.js

------
https://chatgpt.com/codex/tasks/task_e_68d45bc3a8ac832ab4c7dda0b69292ca