### PR TITLE
fix: configure elevated GitHub token for semantic-release

### DIFF
--- a/.github/access-token.yaml
+++ b/.github/access-token.yaml
@@ -6,5 +6,5 @@ policies:
       - "repo:PatrickRuddiman/local-search-mcp:ref:refs/heads/main"
     permissions:
       contents: write
-      pull-requests: write  
+      pull-requests: write
       metadata: read

--- a/.github/access-token.yaml
+++ b/.github/access-token.yaml
@@ -1,0 +1,10 @@
+# Access Token Policy for GitHub Actions
+# This file grants permissions to GitHub Actions workflows to bypass branch protection
+
+policies:
+  - actors: 
+      - "repo:PatrickRuddiman/local-search-mcp:ref:refs/heads/main"
+    permissions:
+      contents: write
+      pull-requests: write  
+      metadata: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get elevated access token
+        id: access-token
+        uses: qoomon/actions--access-token@v3
+        with:
+          permissions: |
+            contents: write
+            pull-requests: write
+            metadata: read
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -42,6 +51,6 @@ jobs:
 
       - name: Run semantic release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.access-token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
This pull request updates the release workflow to use a custom elevated access token for GitHub Actions, allowing the workflow to bypass branch protection and gain additional permissions required for release automation. The changes include introducing a new access token policy and updating the workflow to use this token for semantic release.

**Workflow and permissions improvements:**

* Added `.github/access-token.yaml` to define a policy granting write access to contents and pull requests, and read access to metadata for workflows running on the `main` branch.
* Updated `.github/workflows/release.yml` to:
  * Add a step that retrieves the elevated access token using the `qoomon/actions--access-token@v3` action with the specified permissions.
  * Change the `GITHUB_TOKEN` used by the semantic release step to the output of the new access token step, ensuring the workflow has the required permissions for release tasks.

- Add .github/access-token.yaml policy to grant workflow permissions
- Update release.yml to use qoomon/actions--access-token@v3
- Use elevated token to bypass branch protection for version commits
- Enable semantic-release to push changelog and version updates to main

Resolves semantic-release failure due to protected branch restrictions.